### PR TITLE
Fix workflow: secrets not available in step-level if

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(gh secret:*)",
       "Bash(gh auth:*)",
       "Bash(gh api:*)",
-      "Bash(curl -s -o /dev/null -w \"%{http_code}\" \"https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json\")"
+      "Bash(curl -s -o /dev/null -w \"%{http_code}\" \"https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json\")",
+      "Bash(git pull:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,10 @@
       "Bash(gh --version)",
       "Bash(gh gist:*)",
       "Bash(export 'PATH=$PATH:/c/Program Files/GitHub CLI:/c/Program Files \\(x86\\)/GitHub CLI')",
-      "Bash(gh secret:*)"
+      "Bash(gh secret:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh api:*)",
+      "Bash(curl -s -o /dev/null -w \"%{http_code}\" \"https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json\")"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(where gh:*)",
+      "Bash(cmd.exe /c \"where gh\")",
+      "Bash(export PATH=\"$PATH:/c/Program Files/GitHub CLI:/c/Program Files \\(x86\\)/GitHub CLI\")",
+      "Bash(gh --version)",
+      "Bash(gh gist:*)",
+      "Bash(export 'PATH=$PATH:/c/Program Files/GitHub CLI:/c/Program Files \\(x86\\)/GitHub CLI')",
+      "Bash(gh secret:*)"
+    ]
+  }
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      GIST_SECRET: ${{ secrets.GIST_SECRET }}
+      GIST_ID: ${{ secrets.GIST_ID }}
 
     steps:
     - name: Checkout code
@@ -89,7 +92,7 @@ jobs:
         path: code-coverage-results.md
 
     - name: Create coverage badge
-      if: github.ref == 'refs/heads/main' && secrets.GIST_SECRET != '' && secrets.GIST_ID != ''
+      if: github.ref == 'refs/heads/main' && env.GIST_SECRET != '' && env.GIST_ID != ''
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -89,7 +89,7 @@ jobs:
         path: code-coverage-results.md
 
     - name: Create coverage badge
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && secrets.GIST_SECRET != '' && secrets.GIST_ID != ''
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,7 @@ jobs:
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}
-        gistID: 43220e786710833306a7a0e291f25449
+        gistID: ${{ secrets.GIST_ID }}
         filename: coverage.json
         label: coverage
         message: "${{ steps.coverage.outputs.value }}%"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,23 +9,21 @@ on:
       - main
 
 concurrency:
-  group: coverage-badge-${{ github.ref }}
-  cancel-in-progress: false
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  
+  checks: write
+
 jobs:
   test:
-    if: ${{ github.event_name != 'push' || !((github.actor == 'github-actions' || github.actor == 'github-actions[bot]') && contains(github.event.head_commit.message, '[skip ci]')) }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Set up .NET 10
       uses: actions/setup-dotnet@v4
@@ -46,13 +44,15 @@ jobs:
           --no-build \
           --configuration Release
 
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: '**/TestResults/**/test_results.trx'
+        check_name: 'Test Results'
+
     - name: Install ReportGenerator
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
-    
-    - name: Debug — list coverage files
-      run: |
-        echo "Searching for coverage files..."
-        find . -name "*coverage*" -type f -print
 
     - name: Generate coverage report
       run: |
@@ -73,67 +73,25 @@ jobs:
         value=$(jq '.summary.linecoverage' CoverageReport/Summary.json | xargs printf "%.2f")
         echo "value=$value" >> $GITHUB_OUTPUT
 
-    - name: Add comment to PR
-      if: ${{ github.event_name == 'pull_request' }}
+    - name: Add coverage comment to PR
+      if: github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         message: |
           ## ✔️ Code Coverage Report
-          **Coverage:** `${{ steps.coverage.outputs.value }}%`
+          **Line Coverage:** `${{ steps.coverage.outputs.value }}%`
 
-    - name: Update coverage badge in README
+          📊 [Download full report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+    - name: Create coverage badge
       if: github.ref == 'refs/heads/main'
-      run: |
-        git rm -f coverage-badge.svg || true
-        if [ ! -f "CoverageReport/badge_linecoverage.svg" ]; then
-          echo "badge_linecoverage.svg not found in CoverageReport/."
-          echo "Current contents of CoverageReport/:"
-          ls -la CoverageReport || true
-          exit 1
-        fi
-        cp CoverageReport/badge_linecoverage.svg coverage-badge.svg
-        if grep -q '!\[coverage\]' README.md; then
-          sed -E -i 's|!\[coverage\]\([^)]*\)|![coverage](./coverage-badge.svg)|' README.md
-        else
-          printf '\n![coverage](./coverage-badge.svg)\n' >> README.md
-        fi
-
-    - name: Commit badge update
-      if: github.ref == 'refs/heads/main'
-      run: |
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        git add coverage-badge.svg README.md
-        git commit -m "Update coverage badge [skip ci]" || echo "No changes to commit."
-
-    - name: Push changes
-      if: github.ref == 'refs/heads/main'
-      run: |
-        set -e
-        # Ensure we have the latest main from origin
-        git fetch origin main
-
-        max_retries=3
-        attempt=1
-        while [ "$attempt" -le "$max_retries" ]; do
-          echo "Attempt $attempt of $max_retries: rebasing onto origin/main and pushing..."
-          # Rebase our changes onto the latest origin/main
-          if ! git pull --rebase origin main; then
-            echo "Rebase failed; manual intervention may be required."
-            exit 1
-          fi
-
-          if git push origin HEAD:main; then
-            echo "Push succeeded on attempt $attempt."
-            break
-          fi
-
-          echo "Push failed (non-fast-forward or transient issue). Retrying after a short delay..."
-          attempt=$((attempt + 1))
-          sleep 5
-        done
-
-        if [ "$attempt" -gt "$max_retries" ]; then
-          echo "Failed to push changes to main after $max_retries attempts."
-          exit 1
-        fi
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: ${{ secrets.GIST_ID }}
+        filename: coverage.json
+        label: coverage
+        message: "${{ steps.coverage.outputs.value }}%"
+        valColorRange: ${{ steps.coverage.outputs.value }}
+        minColorRange: 0
+        maxColorRange: 100

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,10 @@ permissions:
 
 jobs:
   test:
+    if: >-
+      !(github.event_name == 'push'
+      && github.actor == 'github-actions[bot]'
+      && contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
     env:
       GIST_SECRET: ${{ secrets.GIST_SECRET }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,22 +73,27 @@ jobs:
         value=$(jq '.summary.linecoverage' CoverageReport/Summary.json | xargs printf "%.2f")
         echo "value=$value" >> $GITHUB_OUTPUT
 
+    - name: Generate coverage summary
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: '**/TestResults/**/coverage.cobertura.xml'
+        badge: true
+        format: markdown
+        output: both
+        thresholds: '40 70'
+
     - name: Add coverage comment to PR
       if: github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        message: |
-          ## ✔️ Code Coverage Report
-          **Line Coverage:** `${{ steps.coverage.outputs.value }}%`
-
-          📊 [Download full report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+        path: code-coverage-results.md
 
     - name: Create coverage badge
       if: github.ref == 'refs/heads/main'
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_SECRET }}
-        gistID: ${{ secrets.GIST_ID }}
+        gistID: 43220e786710833306a7a0e291f25449
         filename: coverage.json
         label: coverage
         message: "${{ steps.coverage.outputs.value }}%"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,10 @@ permissions:
 
 jobs:
   test:
+    if: >-
+      !(github.event_name == 'push'
+        && github.actor == 'github-actions[bot]'
+        && contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
     env:
       GIST_SECRET: ${{ secrets.GIST_SECRET }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/GIST_ID_HERE/raw/coverage.json)
 ![AI Validation](https://github.com/serhiiyasenev/TaskManager/actions/workflows/ai-validation.yml/badge.svg)
 
+> Note: Replace `GIST_ID_HERE` in the Coverage badge URL with your own Gist ID when setting up the project.  
+> The expected format is: `https://gist.githubusercontent.com/<github-username>/<gist-id>/raw/coverage.json`.
+
 **TaskManager** is a multi-component project management and task tracking system built with **.NET 10**, **SignalR**, **RabbitMQ**, **Serilog**, and a layered architecture (**BLL**, **DAL**, **WebAPI**, **Client**, **Notifier**).  
 The system supports **real-time notifications**, **asynchronous task processing**, **analytics**, and **modular expansion**.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # 📝 TaskManager
 
 ![Tests](https://github.com/serhiiyasenev/TaskManager/actions/workflows/run-tests.yml/badge.svg)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/GIST_ID_HERE/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json)
 ![AI Validation](https://github.com/serhiiyasenev/TaskManager/actions/workflows/ai-validation.yml/badge.svg)
-
-> Note: Replace `GIST_ID_HERE` in the Coverage badge URL with your own Gist ID when setting up the project.  
-> The expected format is: `https://gist.githubusercontent.com/<github-username>/<gist-id>/raw/coverage.json`.
 
 **TaskManager** is a multi-component project management and task tracking system built with **.NET 10**, **SignalR**, **RabbitMQ**, **Serilog**, and a layered architecture (**BLL**, **DAL**, **WebAPI**, **Client**, **Notifier**).  
 The system supports **real-time notifications**, **asynchronous task processing**, **analytics**, and **modular expansion**.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # 📝 TaskManager
 
 ![Tests](https://github.com/serhiiyasenev/TaskManager/actions/workflows/run-tests.yml/badge.svg)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/GIST_ID_HERE/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json)
 ![AI Validation](https://github.com/serhiiyasenev/TaskManager/actions/workflows/ai-validation.yml/badge.svg)
-
-> **Note:** To display the coverage badge, replace `GIST_ID_HERE` in the URL above with a real public GitHub Gist ID containing `coverage.json`.
 
 **TaskManager** is a multi-component project management and task tracking system built with **.NET 10**, **SignalR**, **RabbitMQ**, **Serilog**, and a layered architecture (**BLL**, **DAL**, **WebAPI**, **Client**, **Notifier**).  
 The system supports **real-time notifications**, **asynchronous task processing**, **analytics**, and **modular expansion**.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 📝 TaskManager
 
+![Tests](https://github.com/serhiiyasenev/TaskManager/actions/workflows/run-tests.yml/badge.svg)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/GIST_ID_HERE/raw/coverage.json)
+![AI Validation](https://github.com/serhiiyasenev/TaskManager/actions/workflows/ai-validation.yml/badge.svg)
+
 **TaskManager** is a multi-component project management and task tracking system built with **.NET 10**, **SignalR**, **RabbitMQ**, **Serilog**, and a layered architecture (**BLL**, **DAL**, **WebAPI**, **Client**, **Notifier**).  
 The system supports **real-time notifications**, **asynchronous task processing**, **analytics**, and **modular expansion**.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # 📝 TaskManager
 
 ![Tests](https://github.com/serhiiyasenev/TaskManager/actions/workflows/run-tests.yml/badge.svg)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/43220e786710833306a7a0e291f25449/raw/coverage.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/serhiiyasenev/GIST_ID_HERE/raw/coverage.json)
 ![AI Validation](https://github.com/serhiiyasenev/TaskManager/actions/workflows/ai-validation.yml/badge.svg)
+
+> **Note:** To display the coverage badge, replace `GIST_ID_HERE` in the URL above with a real public GitHub Gist ID containing `coverage.json`.
 
 **TaskManager** is a multi-component project management and task tracking system built with **.NET 10**, **SignalR**, **RabbitMQ**, **Serilog**, and a layered architecture (**BLL**, **DAL**, **WebAPI**, **Client**, **Notifier**).  
 The system supports **real-time notifications**, **asynchronous task processing**, **analytics**, and **modular expansion**.


### PR DESCRIPTION
## Summary
- Fix `Unrecognized named-value: 'secrets'` error in `run-tests.yml`
- Move `GIST_SECRET` and `GIST_ID` to job-level `env` and check via `env.*` in step `if` condition
- The `secrets` context cannot be used directly in step-level `if` expressions

## Test plan
- Workflow should pass on main after merge
- Coverage badge step should be skipped gracefully if secrets are empty