### PR TITLE
Fix duplicates in coverage report

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,33 +63,17 @@ jobs:
         files: '**/TestResults/**/test_results.trx'
         check_name: 'Test Results'
 
-    - name: Install coverage tools
-      run: |
-        dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.3.9
-        dotnet tool install -g dotnet-coverage --version 17.9.0
+    - name: Install ReportGenerator
+      run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
-    - name: Merge coverage into single Cobertura file
-      run: |
-        mapfile -t files < <(find ./TestResults -type f -name 'coverage.cobertura.xml' | sort -u)
-
-        if [ ${#files[@]} -eq 0 ]; then
-          echo "No coverage files found"
-          exit 1
-        fi
-
-        echo "Found ${#files[@]} coverage file(s):"
-        printf '  %s\n' "${files[@]}"
-
-        dotnet-coverage merge "${files[@]}" \
-          -f cobertura \
-          -o ./TestResults/coverage.merged.cobertura.xml
-
-    - name: Generate coverage report
+    - name: Merge and generate coverage report
       run: |
         reportgenerator \
-          -reports:"./TestResults/coverage.merged.cobertura.xml" \
+          -reports:"./TestResults/**/coverage.cobertura.xml" \
           -targetdir:"CoverageReport" \
-          -reporttypes:"HtmlInline_AzurePipelines;JsonSummary;Badges"
+          -reporttypes:"HtmlInline_AzurePipelines;JsonSummary;Badges;Cobertura"
+
+        cp CoverageReport/Cobertura.xml ./TestResults/coverage.merged.cobertura.xml
 
     - name: Upload coverage report as artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,8 +65,8 @@ jobs:
 
     - name: Install coverage tools
       run: |
-        dotnet tool install -g dotnet-reportgenerator-globaltool
-        dotnet tool install -g dotnet-coverage
+        dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.3.9
+        dotnet tool install -g dotnet-coverage --version 17.9.0
 
     - name: Merge coverage into single Cobertura file
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,10 +44,14 @@ jobs:
     - name: Build solution
       run: dotnet build TaskManager.sln --configuration Release --no-restore
 
+    - name: Clean old artifacts
+      run: rm -rf TestResults CoverageReport
+
     - name: Run tests with Coverlet
       run: |
         dotnet test TaskManager.sln \
           --settings .runsettings \
+          --results-directory ./TestResults \
           --logger "trx;LogFileName=test_results.trx" \
           --no-build \
           --configuration Release
@@ -59,13 +63,31 @@ jobs:
         files: '**/TestResults/**/test_results.trx'
         check_name: 'Test Results'
 
-    - name: Install ReportGenerator
-      run: dotnet tool install -g dotnet-reportgenerator-globaltool
+    - name: Install coverage tools
+      run: |
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        dotnet tool install -g dotnet-coverage
+
+    - name: Merge coverage into single Cobertura file
+      run: |
+        mapfile -t files < <(find ./TestResults -type f -name 'coverage.cobertura.xml' | sort -u)
+
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No coverage files found"
+          exit 1
+        fi
+
+        echo "Found ${#files[@]} coverage file(s):"
+        printf '  %s\n' "${files[@]}"
+
+        dotnet-coverage merge "${files[@]}" \
+          -f cobertura \
+          -o ./TestResults/coverage.merged.cobertura.xml
 
     - name: Generate coverage report
       run: |
         reportgenerator \
-          -reports:"**/TestResults/**/coverage*.*" \
+          -reports:"./TestResults/coverage.merged.cobertura.xml" \
           -targetdir:"CoverageReport" \
           -reporttypes:"HtmlInline_AzurePipelines;JsonSummary;Badges"
 
@@ -84,7 +106,7 @@ jobs:
     - name: Generate coverage summary
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: '**/TestResults/**/coverage.cobertura.xml'
+        filename: './TestResults/coverage.merged.cobertura.xml'
         badge: true
         format: markdown
         output: both
@@ -94,6 +116,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
+        recreate: true
         path: code-coverage-results.md
 
     - name: Create coverage badge

--- a/.runsettings
+++ b/.runsettings
@@ -5,6 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/TestPlatform/CodeCoverage/Collector/v1">
         <Configuration>
           <Format>cobertura</Format>
+          <ExcludeByFile>**/Migrations/*.cs,**/*.g.cs,**/*.designer.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/.runsettings
+++ b/.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/TestPlatform/CodeCoverage/Collector/v1">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*.g.cs,**/*.designer.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*.g.cs,**/*.designer.cs,**/*.Designer.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
## Summary
- Merge all `coverage.cobertura.xml` into a single file before reporting — eliminates duplicate BLL and DAL entries in PR comments
- Exclude Migrations, `.g.cs`, `.designer.cs` from coverage via `.runsettings`
- Add `recreate: true` to sticky PR comment to avoid stale comments
- Clean old `TestResults`/`CoverageReport` artifacts before each run

## Test plan
- [x] Verify PR coverage comment shows BLL and DAL only once
- [x] Verify coverage badge updates correctly
- [x] Verify coverage percentage is accurate after excluding generated files